### PR TITLE
Update PaperCut.ps1

### DIFF
--- a/PaperCut.ps1
+++ b/PaperCut.ps1
@@ -47,7 +47,7 @@ function Idm-SystemInfo {
                 description = 'Number of records per page'
                 value = '250'
             }
-			@{
+            @{
                 name = 'ignore_ssl_trust'
                 type = 'checkbox'
                 label = 'Skip SSL Trust Check'
@@ -231,7 +231,7 @@ function Idm-UsersRead {
                         </methodCall>' -f $system_params.authtoken, $userList.Count, $system_params.pagesize
 
                         Log info ("Retrieving User List - Offset ($($userList.Count))")
-                        $response = Invoke-PaperCutRequest -SystemParams $system_params -FunctionParams $function_params -Body $xmlRequest
+                        $response = Invoke-PaperCutRequest -system_params $system_params -function_params $function_params -Body $xmlRequest
                         
                         Log info "Retrieving User List - Returned ($($response.methodResponse.params.param.value.array.data.value.count))"
 
@@ -252,164 +252,8 @@ function Idm-UsersRead {
                     foreach($user in $userList) {
                         $i++
                         Log info "Processing user $($i) of $($userList.count)"
-                        $xmlRequest = '<?xml version="1.0" encoding="UTF-8"?>
-                        <methodCall>
-                            <methodName>api.getUserProperties</methodName>
-                            <params>
-                                <param>
-                                    <value>
-                                        <string>{0}</string>
-                                    </value>
-                                </param>
-                                <param>
-                                    <value>
-                                        <string>{1}</string>
-                                    </value>
-                                </param>
-                                <param>
-                                    <value>
-                                        <array>
-                                            <data>
-                                                <value>
-                                                    <string>balance</string>
-                                                </value>
-                                                <value>
-                                                    <string>primary-card-number</string>
-                                                </value>
-                                                <value>
-                                                    <string>secondary-card-number</string>
-                                                </value>
-                                                <value>
-                                                    <string>department</string>
-                                                </value>
-                                                <value>
-                                                    <string>disabled-print</string>
-                                                </value>
-                                                <value>
-                                                    <string>email</string>
-                                                </value>
-                                                <value>
-                                                    <string>full-name</string>
-                                                </value>
-                                                <value>
-                                                    <string>internal</string>
-                                                </value>
-                                                <value>
-                                                    <string>notes</string>
-                                                </value>
-                                                <value>
-                                                    <string>office</string>
-                                                </value>
-                                                <value>
-                                                    <string>delegated-users</string>
-                                                </value>
-                                                <value>
-                                                    <string>delegated-groups</string>
-                                                </value>
-                                                <value>
-                                                    <string>print-stats.job-count</string>
-                                                </value>
-                                                <value>
-                                                    <string>print-stats.page-count</string>
-                                                </value>
-                                                <value>
-                                                    <string>net-stats.data-mb</string>
-                                                </value>
-                                                <value>
-                                                    <string>net-stats.time-hours</string>
-                                                </value>
-                                                <value>
-                                                    <string>restricted</string>
-                                                </value>
-                                                <value>
-                                                    <string>home</string>
-                                                </value>
-                                                <value>
-                                                    <string>unauthenticated</string>
-                                                </value>
-                                                <value>
-                                                    <string>username-alias</string>
-                                                </value>
-                                                <value>
-                                                    <string>dont-hold-jobs-in-release-station</string>
-                                                </value>
-                                                <value>
-                                                    <string>dont-apply-printer-filter-rules</string>
-                                                </value>
-                                                <value>
-                                                    <string>printer-cost-adjustment-rate-percent</string>
-                                                </value>
-                                                <value>
-                                                    <string>dont-archive</string>
-                                                </value>
-                                                <value>
-                                                    <string>auto-release-jobs</string>
-                                                </value>
-                                                <value>
-                                                    <string>overdraft-amount</string>
-                                                </value>
-                                                <value>
-                                                    <string>account-selection.mode</string>
-                                                </value>
-                                                <value>
-                                                    <string>account-selection.can-charge-personal</string>
-                                                </value>
-                                                <value>
-                                                    <string>account-selection.can-charge-shared-from-list</string>
-                                                </value>
-                                                <value>
-                                                    <string>account-selection.can-charge-shared-by-pin</string>
-                                                </value>
-                                                <value>
-                                                    <string>other-emails</string>
-                                                </value>
-                                                <value>
-                                                    <string>auto-shared-account</string>
-                                                </value>
-                                            </data>
-                                        </array>
-                                    </value>
-                                </param>
-                            </params>
-                        </methodCall>' -f $system_params.authtoken, $user
-
-                        $response = Invoke-PaperCutRequest -SystemParams $system_params -FunctionParams $function_params -Body $xmlRequest
-                        $attributes = $response.methodResponse.params.param.value.array.data.value
-                        $userObject = [PSCustomObject]@{
-                            "Username" = $user
-                            "balance" = $attributes[0]
-                            "primary-card-number" = $attributes[1]
-                            "secondary-card-number" = $attributes[2]
-                            "department" = $attributes[3]
-                            "disabled-print" = $attributes[4]
-                            "email" = $attributes[5]
-                            "full-name" = $attributes[6]
-                            "internal" = $attributes[7]
-                            "notes" = $attributes[8]
-                            "office" = $attributes[9]
-                            "delegated-users" = $attributes[10]
-                            "delegated-groups" = $attributes[11]
-                            "print-stats_job-count" = $attributes[12]
-                            "print-stats_page-count" = $attributes[13]
-                            "net-stats_data-mb" = $attributes[14]
-                            "net-stats_time-hours" = $attributes[15]
-                            "restricted" = $attributes[16]
-                            "home" = $attributes[17]
-                            "unauthenticated" = $attributes[18]
-                            "username-alias" = $attributes[19]
-                            "dont-hold-jobs-in-release-station"  = $attributes[20]
-                            "dont-apply-printer-filter-rules" = $attributes[21]
-                            "printer-cost-adjustment-rate-percent" = $attributes[22]
-                            "dont-archive" = $attributes[23]
-                            "auto-release-jobs" = $attributes[24]
-                            "overdraft-amount" = $attributes[25]
-                            "account-selection_mode" = $attributes[26]
-                            "account-selection_can-charge-personal" = $attributes[27]
-                            "account-selection_can-charge-shared-from-list" = $attributes[28]
-                            "account-selection_can-charge-shared-by-pin" = $attributes[29]
-                            "other-emails" = $attributes[30]
-                            "auto-shared-account" = $attributes[31]
-                        }
+                        
+                        $userObject = Get-UserProperties -system_params $system_params -function_params $function_params -username $user
                         
                         [void]$results.Add($userObject)
                     }
@@ -446,7 +290,8 @@ function Idm-UsersRename {
             semantics = 'update'
             parameters = @(
                 @{ name = 'Username';       allowance = 'mandatory'   }
-                @{ name = 'NewUsername';               allowance = 'mandatory' }
+                @{ name = 'NewUsername';    allowance = 'mandatory' }
+                @{ name = '*';              allowance = 'prohibited' }
             )
         }
     }
@@ -484,14 +329,190 @@ function Idm-UsersRename {
 
             Log info ("Renaming User ({0}) to ({1})" -f $properties.Username, $properties.NewUsername)
 
-            $response = Invoke-PaperCutRequest -SystemParams $system_params -FunctionParams $function_params -Body $xmlRequest
+            $response = Invoke-PaperCutRequest -system_params $system_params -function_params $function_params -Body $xmlRequest
             
-			Log info ("Completed Rename for ({0}) to ({1})" -f $properties.Username, $properties.NewUsername)
+            Log info ("Completed Rename for ({0}) to ({1})" -f $properties.Username, $properties.NewUsername)
             
-			# Out new object
-			[PSCustomObject]@{
+            # Out new object
+            [PSCustomObject]@{
                 Username = $properties.NewUsername
             }
+        }
+        catch {
+            Log error "Failed: $_"
+            Write-Error $_
+        }
+    }
+    Log info "Done"
+}
+
+# https://www.papercut.com/help/manuals/ng-mf/common/tools-web-services/#:~:text=set%20to%20%27individual%27-,api.setUserProperties,-Set%20multiple%20user
+<#
+balance: the user's balance, unformatted, e.g. "1234.56".
+primary-card-number
+secondary-card-number
+department
+disabled-print: true if the user's printing is disabled, otherwise false
+email
+full-name
+internal: true if this is an internal user, otherwise false
+notes
+office
+delegated-users: the user names the given user can release print jobs for
+delegated-groups: the group names the given user can release print jobs for
+print-stats.job-count: total number of print jobs from this user, unformatted, e.g. "1234"
+print-stats.page-count: total number of pages printed by this user, unformatted, e.g. "1234"
+net-stats.data-mb: total 'net MB used by this user, unformatted, e.g. "1234.56"
+net-stats.time-hours: total 'net hours used by this user, unformatted, e.g. "1234.56"
+restricted: true if this user's printing is restricted, false if they are unrestricted.
+home: the user's home folder (a double-quoted UNC path)
+unauthenticated: true if the user is an unauthenticated user, {otherwise false
+username-alias: The alias for a given user
+dont-hold-jobs-in-release-station: true if the user's jobs will bypass all release station queues, otherwise false
+dont-apply-printer-filter-rules: true if the user's jobs will bypass printer filter settings, otherwise false
+printer-cost-adjustment-rate-percent: The percentage modifier for the user's job costs, unformatted, e.g. "123.45". If the flag to enable adjustment is not set, returns -1
+dont-archive: true if the user's jobs will not be archived, false otherwise.
+auto-release-jobs: true if the user's jobs will always release on device login, otherwise false
+overdraft-amount: the user's individual overdraft amount, unformatted, e.g. "1234.56". Note this amount is in use only when the user account is restricted and overdraft mode is set to 'individual'
+#>
+function Idm-UsersUpdate {
+    param (
+        # Operations
+        [switch] $GetMeta,
+        # Parameters
+        [string] $SystemParams,
+        [string] $FunctionParams
+    )
+
+    Log info "-GetMeta=$GetMeta -SystemParams='$SystemParams' -FunctionParams='$FunctionParams'"
+
+    if ($GetMeta) {
+        #
+        # Get meta data
+        #
+
+        @{
+            semantics = 'update'
+            parameters = @(
+                @{ name = 'Username';                               allowance = 'mandatory'   }
+                @{ name = 'balance';                                allowance = 'optional'    }
+                @{ name = 'primary-card-number';                    allowance = 'optional'    }
+                @{ name = 'secondary-card-number';                  allowance = 'optional'    }
+                @{ name = 'department';                             allowance = 'optional'    }
+                @{ name = 'disabled-print';                         allowance = 'optional'    }
+                @{ name = 'email';                                  allowance = 'optional'    }
+                @{ name = 'full-name';                              allowance = 'optional'    }
+                @{ name = 'internal';                               allowance = 'optional'    }
+                @{ name = 'notes';                                  allowance = 'optional'    }
+                @{ name = 'office';                                 allowance = 'optional'    }
+                @{ name = 'delegated-users';                        allowance = 'optional'    }
+                @{ name = 'delegated-groups';                       allowance = 'optional'    }
+                @{ name = 'print-stats.job-count';                  allowance = 'optional'    }
+                @{ name = 'print-stats.page-count';                 allowance = 'optional'    }
+                @{ name = 'net-stats.data-mb';                      allowance = 'optional'    }
+                @{ name = 'net-stats.time-hours';                   allowance = 'optional'    }
+                @{ name = 'restricted';                             allowance = 'optional'    }
+                @{ name = 'home';                                   allowance = 'optional'    }
+                @{ name = 'unauthenticated';                        allowance = 'optional'    }
+                @{ name = 'username-alias';                         allowance = 'optional'    }
+                @{ name = 'dont-hold-jobs-in-release-station';      allowance = 'optional'    }
+                @{ name = 'dont-apply-printer-filter-rules';        allowance = 'optional'    }
+                @{ name = 'printer-cost-adjustment-rate-percent';   allowance = 'optional'    }
+                @{ name = 'dont-archive';                           allowance = 'optional'    }
+                @{ name = 'auto-release-jobs';                      allowance = 'optional'    }
+                @{ name = 'overdraft-amount';                       allowance = 'optional'    } 
+                @{ name = '*';                                      allowance = 'prohibited'  }
+            )
+        }
+    }
+    else {
+        #
+        # Execute function
+        #
+        $system_params = ConvertFrom-Json2 $SystemParams
+        $function_params   = ConvertFrom-Json2 $FunctionParams
+        
+        $properties = $function_params.Clone()
+        $properties.remove('Username')
+
+        # Parse Properties to update.
+        $propertiesXML = '';
+        foreach($prop in $properties.GetEnumerator()) {
+            $propertiesXML += @'
+    <value>
+        <array>
+            <data>
+                <value>
+                    <string>{0}</string>
+                </value>
+                <value>
+                    <string>{1}</string>
+                </value>
+            </data>
+        </array>
+    </value>
+'@ -f $prop.name, $prop.value
+            
+            Log info ("Updating Properties for User ({0}), ({1}) to ({2})" -f $function_params.username, $prop.Name, $prop.Value)
+        } #end foreach
+        # Example Updated Property
+        <#
+        <value>
+            <array>
+                <data>
+                    <value>
+                        <string>department</string>
+                    </value>
+                    <value>
+                        <string>newdept</string>
+                    </value>
+                </data>
+            </array>
+        </value>
+        #>
+
+        try {
+            $xmlRequest = '<?xml version="1.0" encoding="UTF-8"?>
+                        <methodCall>
+                            <methodName>api.setUserProperties</methodName>
+                            <params>
+                                <param>
+                                    <value>
+                                        <string>{0}</string>
+                                    </value>
+                                </param>
+                                <param>
+                                    <value>
+                                        <string>{1}</string>
+                                    </value>
+                                </param>
+                                <param>
+                                    <value>
+                                        <array>
+                                            <data>
+                                                {2}
+                                            </data>
+                                        </array>
+                                    </value>
+                                </param>
+                            </params>
+                        </methodCall>' -f $system_params.authtoken, $properties.Username, $propertiesXML
+
+            $response = Invoke-PaperCutRequest -system_params $system_params -function_params $function_params -Body $xmlRequest
+            
+            # Output is a boolean.
+            if ($response = 1) {
+                
+                Log info ("Completed Update Properties for ({0}), response: ({1})" -f $properties.Username, ($response | ConvertTo-Json -Depth 5))
+            
+            } else {
+            
+                #Log error ("Failed to Update Properties for ({0}), response: ({1})" -f $properties.Username, ($response | ConvertTo-Json -Depth 5))
+                throw ("Failed to Update Properties for ({0}), response: ({1})" -f $properties.Username, ($response | ConvertTo-Json -Depth 5))
+            
+            }
+            # Out new object
+            Get-UserProperties -system_params $system_params -function_params $function_params -username $function_params.Username
         }
         catch {
             Log error "Failed: $_"
@@ -505,39 +526,208 @@ function Idm-UsersRename {
 # Functions
 # 
 
+function Get-UserProperties {
+    param (
+        [hashtable] $system_params,
+        [hashtable] $function_params,
+        [string] $username
+    )
+
+    $xmlRequest = '<?xml version="1.0" encoding="UTF-8"?>
+        <methodCall>
+            <methodName>api.getUserProperties</methodName>
+            <params>
+                <param>
+                    <value>
+                        <string>{0}</string>
+                    </value>
+                </param>
+                <param>
+                    <value>
+                        <string>{1}</string>
+                    </value>
+                </param>
+                <param>
+                    <value>
+                        <array>
+                            <data>
+                                <value>
+                                    <string>balance</string>
+                                </value>
+                                <value>
+                                    <string>primary-card-number</string>
+                                </value>
+                                <value>
+                                    <string>secondary-card-number</string>
+                                </value>
+                                <value>
+                                    <string>department</string>
+                                </value>
+                                <value>
+                                    <string>disabled-print</string>
+                                </value>
+                                <value>
+                                    <string>email</string>
+                                </value>
+                                <value>
+                                    <string>full-name</string>
+                                </value>
+                                <value>
+                                    <string>internal</string>
+                                </value>
+                                <value>
+                                    <string>notes</string>
+                                </value>
+                                <value>
+                                    <string>office</string>
+                                </value>
+                                <value>
+                                    <string>delegated-users</string>
+                                </value>
+                                <value>
+                                    <string>delegated-groups</string>
+                                </value>
+                                <value>
+                                    <string>print-stats.job-count</string>
+                                </value>
+                                <value>
+                                    <string>print-stats.page-count</string>
+                                </value>
+                                <value>
+                                    <string>net-stats.data-mb</string>
+                                </value>
+                                <value>
+                                    <string>net-stats.time-hours</string>
+                                </value>
+                                <value>
+                                    <string>restricted</string>
+                                </value>
+                                <value>
+                                    <string>home</string>
+                                </value>
+                                <value>
+                                    <string>unauthenticated</string>
+                                </value>
+                                <value>
+                                    <string>username-alias</string>
+                                </value>
+                                <value>
+                                    <string>dont-hold-jobs-in-release-station</string>
+                                </value>
+                                <value>
+                                    <string>dont-apply-printer-filter-rules</string>
+                                </value>
+                                <value>
+                                    <string>printer-cost-adjustment-rate-percent</string>
+                                </value>
+                                <value>
+                                    <string>dont-archive</string>
+                                </value>
+                                <value>
+                                    <string>auto-release-jobs</string>
+                                </value>
+                                <value>
+                                    <string>overdraft-amount</string>
+                                </value>
+                                <value>
+                                    <string>account-selection.mode</string>
+                                </value>
+                                <value>
+                                    <string>account-selection.can-charge-personal</string>
+                                </value>
+                                <value>
+                                    <string>account-selection.can-charge-shared-from-list</string>
+                                </value>
+                                <value>
+                                    <string>account-selection.can-charge-shared-by-pin</string>
+                                </value>
+                                <value>
+                                    <string>other-emails</string>
+                                </value>
+                                <value>
+                                    <string>auto-shared-account</string>
+                                </value>
+                            </data>
+                        </array>
+                    </value>
+                </param>
+            </params>
+        </methodCall>' -f $system_params.authtoken, $username
+
+        $response = Invoke-PaperCutRequest -system_params $system_params -function_params $function_params -Body $xmlRequest
+        $attributes = $response.methodResponse.params.param.value.array.data.value
+        $userObject = [PSCustomObject]@{
+            "Username" = $username
+            "balance" = $attributes[0]
+            "primary-card-number" = $attributes[1]
+            "secondary-card-number" = $attributes[2]
+            "department" = $attributes[3]
+            "disabled-print" = $attributes[4]
+            "email" = $attributes[5]
+            "full-name" = $attributes[6]
+            "internal" = $attributes[7]
+            "notes" = $attributes[8]
+            "office" = $attributes[9]
+            "delegated-users" = $attributes[10]
+            "delegated-groups" = $attributes[11]
+            "print-stats_job-count" = $attributes[12]
+            "print-stats_page-count" = $attributes[13]
+            "net-stats_data-mb" = $attributes[14]
+            "net-stats_time-hours" = $attributes[15]
+            "restricted" = $attributes[16]
+            "home" = $attributes[17]
+            "unauthenticated" = $attributes[18]
+            "username-alias" = $attributes[19]
+            "dont-hold-jobs-in-release-station"  = $attributes[20]
+            "dont-apply-printer-filter-rules" = $attributes[21]
+            "printer-cost-adjustment-rate-percent" = $attributes[22]
+            "dont-archive" = $attributes[23]
+            "auto-release-jobs" = $attributes[24]
+            "overdraft-amount" = $attributes[25]
+            "account-selection_mode" = $attributes[26]
+            "account-selection_can-charge-personal" = $attributes[27]
+            "account-selection_can-charge-shared-from-list" = $attributes[28]
+            "account-selection_can-charge-shared-by-pin" = $attributes[29]
+            "other-emails" = $attributes[30]
+            "auto-shared-account" = $attributes[31]
+        }
+        
+        $userObject
+}
+
 function Invoke-PaperCutRequest {
     param (
-        [hashtable] $SystemParams,
-        [hashtable] $FunctionParams,
+        [hashtable] $system_params,
+        [hashtable] $function_params,
         [string] $Body
-
     )
+
     if($system_params.ignore_ssl_trust) {
-		add-type @"
-	using System.Net;
-	using System.Security.Cryptography.X509Certificates;
-	public class TrustAllCertsPolicy : ICertificatePolicy {
-		public bool CheckValidationResult(
-			ServicePoint srvPoint, X509Certificate certificate,
-			WebRequest request, int certificateProblem) {
-			return true;
-		}
-	}
+        add-type @"
+    using System.Net;
+    using System.Security.Cryptography.X509Certificates;
+    public class TrustAllCertsPolicy : ICertificatePolicy {
+        public bool CheckValidationResult(
+            ServicePoint srvPoint, X509Certificate certificate,
+            WebRequest request, int certificateProblem) {
+            return true;
+        }
+    }
 "@
 [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Ssl3, [Net.SecurityProtocolType]::Tls, [Net.SecurityProtocolType]::Tls11, [Net.SecurityProtocolType]::Tls12
-	}
-	
-	$uri = "https://{0}:9192/rpc/api/xmlrpc" -f $SystemParams.hostname
+    }
+    
+    $uri = "https://{0}:9192/rpc/api/xmlrpc" -f $system_params.hostname
 
    
     $headers= @{
-		'Content-Type' = 'text/xml;charset=UTF-8'
-	}
-	
+        'Content-Type' = 'text/xml;charset=UTF-8'
+    }
+    
     try {
-		$splat = @{
+        $splat = @{
             Method = "POST"
             Uri = $uri
             Headers = $headers
@@ -557,8 +747,8 @@ function Invoke-PaperCutRequest {
 
         $response = Invoke-RestMethod @splat -ErrorAction Stop
         $result = [xml]$response
-	}
-	catch [System.Net.WebException] {
+    }
+    catch [System.Net.WebException] {
        
         try {
             $reader = New-Object System.IO.StreamReader -ArgumentList $_.Exception.Response.GetResponseStream()
@@ -572,7 +762,7 @@ function Invoke-PaperCutRequest {
         $message = "Error : $($_)"
         Log error $message
         Write-Error $_
-	}
+    }
     catch {
         $message = "Error : $($_)"
         Log error $message

--- a/PaperCut.ps1
+++ b/PaperCut.ps1
@@ -327,11 +327,11 @@ function Idm-UsersRename {
                             </params>
                         </methodCall>' -f $system_params.authtoken, $properties.Username, $properties.NewUsername
 
-            Log info ("Renaming User ({0}) to ({1})" -f $properties.Username, $properties.NewUsername)
+            LogIO info 'Idm-UsersRename' -In @system_params -Properties $properties
 
             $response = Invoke-PaperCutRequest -system_params $system_params -function_params $function_params -Body $xmlRequest
             
-            Log info ("Completed Rename for ({0}) to ({1})" -f $properties.Username, $properties.NewUsername)
+            LogIO info 'Idm-UsersRename' -Out -Response $response
             
             # Out new object
             [PSCustomObject]@{
@@ -339,7 +339,7 @@ function Idm-UsersRename {
             }
         }
         catch {
-            Log error "Failed: $_"
+            LogIO error 'Idm-UsersRename' -Out -Response $_
             Write-Error $_
         }
     }
@@ -452,8 +452,6 @@ function Idm-UsersUpdate {
         </array>
     </value>
 '@ -f $prop.name, $prop.value
-            
-            Log info ("Updating Properties for User ({0}), ({1}) to ({2})" -f $function_params.username, $prop.Name, $prop.Value)
         } #end foreach
         # Example Updated Property
         <#
@@ -497,17 +495,20 @@ function Idm-UsersUpdate {
                                 </param>
                             </params>
                         </methodCall>' -f $system_params.authtoken, $properties.Username, $propertiesXML
-
+            
+            LogIO info 'Idm-UsersUpdate' -In -Parameters $function_params
+            
             $response = Invoke-PaperCutRequest -system_params $system_params -function_params $function_params -Body $xmlRequest
             
             # Output is a boolean.
             if ($response = 1) {
                 
-                Log info ("Completed Update Properties for ({0}), response: ({1})" -f $properties.Username, ($response | ConvertTo-Json -Depth 5))
+                LogIO info 'Idm-UsersUpdate' -Out -Response $response
             
             } else {
             
                 #Log error ("Failed to Update Properties for ({0}), response: ({1})" -f $properties.Username, ($response | ConvertTo-Json -Depth 5))
+                LogIO error 'Idm-UsersUpdate' -Out -Response $response
                 throw ("Failed to Update Properties for ({0}), response: ({1})" -f $properties.Username, ($response | ConvertTo-Json -Depth 5))
             
             }


### PR DESCRIPTION
- Replace tabs with spaces.
- Extract Get-UserProperties into its own function.
- Add Update-UserProperties function.  Includes only properties that are included in mapping. 
- Fix wrongly referenced SystemParams in Invoke-Papercut function.  Updated all references so it is clear the function expects a hashTable, not the JSON. 
- Update Rename mapping to only show the Current and New Username properties.